### PR TITLE
Fix compilation problems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.4)
+project(boost_asio_bluetooth VERSION "0.1.0" LANGUAGES CXX)
+string(REGEX MATCHALL "[0-9]" PROJECT_VERSION_PARTS "${PROJECT_VERSION}")
+set(PROJECT_SOVERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}")
+list(GET PROJECT_VERSION_PARTS 0 PROJECT_VERSION_MAJOR)
+list(GET PROJECT_VERSION_PARTS 1 PROJECT_VERSION_MINOR)
+list(GET PROJECT_VERSION_PARTS 2 PROJECT_VERSION_PATCH)
+set(PROJECT_SOVERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}")
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+IF(NOT CMAKE_BUILD_TYPE)
+   SET(CMAKE_BUILD_TYPE "Release")
+   MESSAGE(STATUS ${CMAKE_BUILD_TYPE})
+ENDIF()
+
+# Find boost
+find_package(Boost REQUIRED system thread)
+if (Boost_FOUND)
+    INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIRS})
+    LINK_DIRECTORIES(${Boost_LIBRARY_DIRS})
+    add_definitions("-DHAS_BOOST")
+else(Boost_FOUND)
+        message(FATAL_ERROR "Boost not found")
+endif()
+# Find bluetooth
+find_library(bluetooth_LIBS NAMES bluetooth PATHS /usr/lib/ /usr/lib/x86_64-linux-gnu)
+IF(NOT bluetooth_LIBS)
+    message(FATAL_ERROR "Could not find bluetooth library. Please install libbluetooth-dev library.")
+ENDIF()
+SET(REQUIRED_LIBRARIES ${Boost_LIBRARIES} ${bluetooth_LIBS} pthread)
+
+
+MESSAGE(STATUS "REQUIRED_LIBRARIES=${REQUIRED_LIBRARIES}")
+add_executable(echo_server echoserver.cpp wrapper.cpp)
+target_link_libraries(echo_server ${REQUIRED_LIBRARIES})
+
+add_executable(echo_client echoclient.cpp wrapper.cpp)
+target_link_libraries(echo_client ${REQUIRED_LIBRARIES})

--- a/asio_bluetooth/detail/endpoint.hpp
+++ b/asio_bluetooth/detail/endpoint.hpp
@@ -35,7 +35,7 @@ public:
     : data_()
   {
     data_.bt.rc_family = AF_BLUETOOTH;
-    data_.bt.rc_bdaddr = *BDADDR_ANY;
+    data_.bt.rc_bdaddr = (bdaddr_t) { 0 };
     data_.bt.rc_channel = (uint8_t) 1;
     // TODO can we figure out the BT mac of the local host?
     mac_ = "[BDADDR_ANY]";
@@ -45,7 +45,7 @@ public:
     : data_()
   {
     data_.bt.rc_family = AF_BLUETOOTH;
-    data_.bt.rc_bdaddr = *BDADDR_ANY;
+    data_.bt.rc_bdaddr = (bdaddr_t) { 0 };
     data_.bt.rc_channel = (uint8_t) channel;
     // TODO can we figure out the BT mac of the local host?
     mac_ = "[BDADDR_ANY]";

--- a/wrapper.cpp
+++ b/wrapper.cpp
@@ -401,10 +401,18 @@ boost::asio::bluetooth::bluetooth::socket &Connection::GetSocket()
 }
 
 // Connection::GetStrand definition
+#if BOOST_ASIO_VERSION >= 101200 // Boost 1.66+
+boost::asio::io_context::strand &Connection::GetStrand()
+{
+    return m_io_strand;
+}
+#else
 boost::asio::strand &Connection::GetStrand()
 {
-	return m_io_strand;
+    return m_io_strand;
+    return m_io_strand;
 }
+#endif
 
 // Connection::GetHive definition
 boost::shared_ptr<Hive> Connection::GetHive()

--- a/wrapper.h
+++ b/wrapper.h
@@ -67,7 +67,11 @@ class Acceptor : public boost::enable_shared_from_this<Acceptor>
 private:
 	boost::shared_ptr< Hive > m_hive;
 	boost::asio::bluetooth::bluetooth::acceptor m_acceptor;
-	boost::asio::strand m_io_strand;
+#if BOOST_ASIO_VERSION >= 101200 // Boost 1.66+
+    boost::asio::io_context::strand m_io_strand;
+#else
+    boost::asio::strand m_io_strand;
+#endif
 	boost::asio::deadline_timer m_timer;
 	boost::posix_time::ptime m_last_time;
 	boost::int32_t m_timer_interval;
@@ -110,7 +114,11 @@ public:
 	boost::asio::bluetooth::bluetooth::acceptor &GetAcceptor();
 
 	// Returns the strand object.
-	boost::asio::strand &GetStrand();
+#if BOOST_ASIO_VERSION >= 101200 // Boost 1.66+
+    boost::asio::io_context::strand &GetStrand();
+#else
+    boost::asio::strand &GetStrand();
+#endif
 
 	// Sets the timer interval of the object. The interval is changed after
 	// the next update is called. The default value is 1000 ms.
@@ -150,7 +158,11 @@ class Connection : public boost::enable_shared_from_this<Connection>
 private:
 	boost::shared_ptr<Hive> m_hive;
 	boost::asio::bluetooth::bluetooth::socket m_socket;
-	boost::asio::strand m_io_strand;
+#if BOOST_ASIO_VERSION >= 101200 // Boost 1.66+
+    boost::asio::io_context::strand m_io_strand;
+#else
+    boost::asio::strand m_io_strand;
+#endif
 	boost::asio::deadline_timer m_timer;
 	boost::posix_time::ptime m_last_time;
 	std::vector<boost::uint8_t> m_recv_buffer;
@@ -208,7 +220,11 @@ public:
 	boost::asio::bluetooth::bluetooth::socket &GetSocket();
 
 	// Returns the strand object.
-	boost::asio::strand &GetStrand();
+#if BOOST_ASIO_VERSION >= 101200 // Boost 1.66+
+    boost::asio::io_context::strand &GetStrand();
+#else
+    boost::asio::strand &GetStrand();
+#endif
 
 	// Sets the application specific receive buffer size used. For stream
 	// based protocols such as HTTP, you want this to be pretty large, like


### PR DESCRIPTION
This PR fixes:

- The compilation problems caused by the deprecation of `boost::asio::strand` in Boost 1.66, which is replaced by `boost::asio::io_context::strand`
- The compilation error "taking the address of a temporary object of type 'bdaddr_t'" caused by the declaration of rc_bdaddr using a expanded macro.